### PR TITLE
Locked files don't get deleted with python 3.3 and later.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ilock v.1.0.2
+# ilock v.1.0.3
 
 
 ## About

--- a/ilock/__init__.py
+++ b/ilock/__init__.py
@@ -54,7 +54,7 @@ class ILock(object):
         if self._enter_count > 0:
             return
 
-        if sys.platform == 'linux2':
+        if sys.platform.startswith('linux'):
             # In Linux you can delete a locked file
             os.unlink(self._filepath)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='ilock',
     packages=['ilock'],
-    version='1.0.2',
+    version='1.0.3',
     description='Inter-process named lock library',
     author='SymonSoft',
     author_email='symonsoft@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,17 @@
 from setuptools import setup
 
+version = '1.0.3'
 
 setup(
     name='ilock',
     packages=['ilock'],
-    version='1.0.3',
+    version=version,
     description='Inter-process named lock library',
     author='SymonSoft',
     author_email='symonsoft@gmail.com',
     url='https://github.com/symonsoft/ilock',
-    download_url='https://github.com/symonsoft/ilock/tarball/1.0.2',
+    download_url='https://github.com/symonsoft/ilock/tarball/{0}'.format(
+        version),
     keywords=['interprocess', 'multiprocessing', 'lock', 'mutex', 'os-independent'],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
As per the python documentation:
Changed in version 2.7.3: Since lots of code check for sys.platform ==
'linux2', and there is no essential change between Linux 2.x and 3.x,
sys.platform is always set to 'linux2', even on Linux 3.x. In Python 3.3
and later, the value will always be set to 'linux', so it is recommended
to always use the startswith idiom presented above.

https://docs.python.org/2/library/sys.html#sys.platform