### PR TITLE
portalocker major release breaks ilock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Topic :: Utilities'
     ],
-    install_requires=['portalocker']
+    install_requires=['portalocker<2']
 )


### PR DESCRIPTION
Release of version 2.0 of portalocker https://pypi.org/project/portalocker/#history breaks iLock in python 2. A condition to use earlier versions of portalocker is necessary until version 2.0 is supported by ilock. Example exception caused by the portalocker release is available below:

2020-08-04 01:51:03,146 - Thread-7driver - ERROR: Unexpected Python Exception Occurred:
Traceback (most recent call last):
  File "/home/pipelines/result_aggregation/driver.py", line 45, in <module>
    from package.app import *
  File "/home/pipelines/result_aggregation/package/app.py", line 8, in <module>
    from ilock import ILock
  File "/usr/bin/anaconda/lib/python2.7/site-packages/ilock/__init__.py", line 8, in <module>
    import portalocker
  File "/usr/bin/anaconda/lib/python2.7/site-packages/portalocker/__init__.py", line 5, in <module>
    from . import utils
  File "/usr/bin/anaconda/lib/python2.7/site-packages/portalocker/utils.py", line 290
    def __init__(self, maximum: int, name: str = 'bounded_semaphore',
                              ^
SyntaxError: invalid syntax